### PR TITLE
Fix deprecation error on Node >10 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 /coverage
 /node_modules
+/.nyc_output
+package-lock.json
+yarn.lock

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,9 @@
 language: node_js
 node_js:
-  - "0.10"
+  - 13
+  - 12
+  - 10
+  - 8
 script:
   - "npm run test-travis"
 after_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,4 @@ node_js:
   - 10
   - 8
 script:
-  - "npm run test-travis"
-after_script:
-  - "npm install coveralls@2 && cat ./coverage/lcov.info | ./node_modules/.bin/coveralls"
+  - "npm run test:coverage"

--- a/index.js
+++ b/index.js
@@ -106,7 +106,12 @@ ReadStream.prototype._read = function(n) {
   }
   self.context.pend.go(function(cb) {
     if (self.destroyed) return cb();
-    var buffer = new Buffer(toRead);
+    var isModern = (
+      typeof Buffer.alloc === 'function' &&
+      typeof Buffer.allocUnsafe === 'function' &&
+      typeof Buffer.from === 'function'
+    )
+    var buffer = isModern ? Buffer.alloc(toRead) : new Buffer(toRead);
     fs.read(self.context.fd, buffer, 0, toRead, self.pos, function(err, bytesRead) {
       if (err) {
         self.destroy(err);

--- a/index.js
+++ b/index.js
@@ -1,296 +1,277 @@
-var fs = require('fs');
-var util = require('util');
-var stream = require('stream');
-var Readable = stream.Readable;
-var Writable = stream.Writable;
-var PassThrough = stream.PassThrough;
-var Pend = require('pend');
-var EventEmitter = require('events').EventEmitter;
+const fs = require('fs');
+const { Readable, Writable, PassThrough } = require('stream');
+const Pend = require('pend');
+const { EventEmitter } = require('events');
 
-exports.createFromBuffer = createFromBuffer;
-exports.createFromFd = createFromFd;
-exports.BufferSlicer = BufferSlicer;
-exports.FdSlicer = FdSlicer;
+class FdSlicer extends EventEmitter {
+  constructor(fd, options = {}) {
+    super();
 
-util.inherits(FdSlicer, EventEmitter);
-function FdSlicer(fd, options) {
-  options = options || {};
-  EventEmitter.call(this);
-
-  this.fd = fd;
-  this.pend = new Pend();
-  this.pend.max = 1;
-  this.refCount = 0;
-  this.autoClose = !!options.autoClose;
-}
-
-FdSlicer.prototype.read = function(buffer, offset, length, position, callback) {
-  var self = this;
-  self.pend.go(function(cb) {
-    fs.read(self.fd, buffer, offset, length, position, function(err, bytesRead, buffer) {
-      cb();
-      callback(err, bytesRead, buffer);
-    });
-  });
-};
-
-FdSlicer.prototype.write = function(buffer, offset, length, position, callback) {
-  var self = this;
-  self.pend.go(function(cb) {
-    fs.write(self.fd, buffer, offset, length, position, function(err, written, buffer) {
-      cb();
-      callback(err, written, buffer);
-    });
-  });
-};
-
-FdSlicer.prototype.createReadStream = function(options) {
-  return new ReadStream(this, options);
-};
-
-FdSlicer.prototype.createWriteStream = function(options) {
-  return new WriteStream(this, options);
-};
-
-FdSlicer.prototype.ref = function() {
-  this.refCount += 1;
-};
-
-FdSlicer.prototype.unref = function() {
-  var self = this;
-  self.refCount -= 1;
-
-  if (self.refCount > 0) return;
-  if (self.refCount < 0) throw new Error("invalid unref");
-
-  if (self.autoClose) {
-    fs.close(self.fd, onCloseDone);
+    this.fd = fd;
+    this.pend = new Pend();
+    this.pend.max = 1;
+    this.refCount = 0;
+    this.autoClose = !!options.autoClose;
   }
 
-  function onCloseDone(err) {
-    if (err) {
-      self.emit('error', err);
-    } else {
-      self.emit('close');
+  read(buffer, offset, length, position, callback) {
+    this.pend.go(cb => {
+      fs.read(this.fd, buffer, offset, length, position, (err, bytesRead, buffer) => {
+        cb();
+        callback(err, bytesRead, buffer);
+      });
+    });
+  }
+
+  write(buffer, offset, length, position, callback) {
+    this.pend.go(cb => {
+      fs.write(this.fd, buffer, offset, length, position, (err, written, buffer) => {
+        cb();
+        callback(err, written, buffer);
+      });
+    });
+  }
+
+  createReadStream(options) {
+    return new ReadStream(this, options);
+  }
+
+  createWriteStream(options) {
+    return new WriteStream(this, options);
+  }
+
+  ref() {
+    this.refCount += 1;
+  }
+
+  unref() {
+    this.refCount -= 1;
+
+    if (this.refCount > 0) return;
+    if (this.refCount < 0) throw new Error("invalid unref");
+
+    if (this.autoClose) {
+      fs.close(this.fd, err => {
+        if (err) {
+          this.emit('error', err);
+        } else {
+          this.emit('close');
+        }
+      });
     }
   }
-};
-
-util.inherits(ReadStream, Readable);
-function ReadStream(context, options) {
-  options = options || {};
-  Readable.call(this, options);
-
-  this.context = context;
-  this.context.ref();
-
-  this.start = options.start || 0;
-  this.endOffset = options.end;
-  this.pos = this.start;
-  this.destroyed = false;
 }
 
-ReadStream.prototype._read = function(n) {
-  var self = this;
-  if (self.destroyed) return;
+class ReadStream extends Readable {
+  constructor(context, options = {}) {
+    super(options);
 
-  var toRead = Math.min(self._readableState.highWaterMark, n);
-  if (self.endOffset != null) {
-    toRead = Math.min(toRead, self.endOffset - self.pos);
+    this.context = context;
+    this.context.ref();
+
+    this.start = options.start || 0;
+    this.endOffset = options.end;
+    this.pos = this.start;
+    this.destroyed = false;
   }
-  if (toRead <= 0) {
-    self.destroyed = true;
-    self.push(null);
-    self.context.unref();
-    return;
-  }
-  self.context.pend.go(function(cb) {
-    if (self.destroyed) return cb();
-    var isModern = (
-      typeof Buffer.alloc === 'function' &&
-      typeof Buffer.allocUnsafe === 'function' &&
-      typeof Buffer.from === 'function'
-    )
-    var buffer = isModern ? Buffer.alloc(toRead) : new Buffer(toRead);
-    fs.read(self.context.fd, buffer, 0, toRead, self.pos, function(err, bytesRead) {
-      if (err) {
-        self.destroy(err);
-      } else if (bytesRead === 0) {
-        self.destroyed = true;
-        self.push(null);
-        self.context.unref();
-      } else {
-        self.pos += bytesRead;
-        self.push(buffer.slice(0, bytesRead));
-      }
-      cb();
-    });
-  });
-};
 
-ReadStream.prototype.destroy = function(err) {
-  if (this.destroyed) return;
-  err = err || new Error("stream destroyed");
-  this.destroyed = true;
-  this.emit('error', err);
-  this.context.unref();
-};
+  _read(n) {
+    if (this.destroyed) return;
 
-util.inherits(WriteStream, Writable);
-function WriteStream(context, options) {
-  options = options || {};
-  Writable.call(this, options);
-
-  this.context = context;
-  this.context.ref();
-
-  this.start = options.start || 0;
-  this.endOffset = (options.end == null) ? Infinity : +options.end;
-  this.bytesWritten = 0;
-  this.pos = this.start;
-  this.destroyed = false;
-
-  this.on('finish', this.destroy.bind(this));
-}
-
-WriteStream.prototype._write = function(buffer, encoding, callback) {
-  var self = this;
-  if (self.destroyed) return;
-
-  if (self.pos + buffer.length > self.endOffset) {
-    var err = new Error("maximum file length exceeded");
-    err.code = 'ETOOBIG';
-    self.destroy();
-    callback(err);
-    return;
-  }
-  self.context.pend.go(function(cb) {
-    if (self.destroyed) return cb();
-    fs.write(self.context.fd, buffer, 0, buffer.length, self.pos, function(err, bytes) {
-      if (err) {
-        self.destroy();
-        cb();
-        callback(err);
-      } else {
-        self.bytesWritten += bytes;
-        self.pos += bytes;
-        self.emit('progress');
-        cb();
-        callback();
-      }
-    });
-  });
-};
-
-WriteStream.prototype.destroy = function() {
-  if (this.destroyed) return;
-  this.destroyed = true;
-  this.context.unref();
-};
-
-util.inherits(BufferSlicer, EventEmitter);
-function BufferSlicer(buffer, options) {
-  EventEmitter.call(this);
-
-  options = options || {};
-  this.refCount = 0;
-  this.buffer = buffer;
-  this.maxChunkSize = options.maxChunkSize || Number.MAX_SAFE_INTEGER;
-}
-
-BufferSlicer.prototype.read = function(buffer, offset, length, position, callback) {
-  var end = position + length;
-  var delta = end - this.buffer.length;
-  var written = (delta > 0) ? delta : length;
-  this.buffer.copy(buffer, offset, position, end);
-  setImmediate(function() {
-    callback(null, written);
-  });
-};
-
-BufferSlicer.prototype.write = function(buffer, offset, length, position, callback) {
-  buffer.copy(this.buffer, position, offset, offset + length);
-  setImmediate(function() {
-    callback(null, length, buffer);
-  });
-};
-
-BufferSlicer.prototype.createReadStream = function(options) {
-  options = options || {};
-  var readStream = new PassThrough(options);
-  readStream.destroyed = false;
-  readStream.start = options.start || 0;
-  readStream.endOffset = options.end;
-  // by the time this function returns, we'll be done.
-  readStream.pos = readStream.endOffset || this.buffer.length;
-
-  // respect the maxChunkSize option to slice up the chunk into smaller pieces.
-  var entireSlice = this.buffer.slice(readStream.start, readStream.pos);
-  var offset = 0;
-  while (true) {
-    var nextOffset = offset + this.maxChunkSize;
-    if (nextOffset >= entireSlice.length) {
-      // last chunk
-      if (offset < entireSlice.length) {
-        readStream.write(entireSlice.slice(offset, entireSlice.length));
-      }
-      break;
+    let toRead = Math.min(this._readableState.highWaterMark, n);
+    if (this.endOffset != null) {
+      toRead = Math.min(toRead, this.endOffset - this.pos);
     }
-    readStream.write(entireSlice.slice(offset, nextOffset));
-    offset = nextOffset;
+    if (toRead <= 0) {
+      this.destroyed = true;
+      this.push(null);
+      this.context.unref();
+      return;
+    }
+    this.context.pend.go(cb => {
+      if (this.destroyed) return cb();
+      const buffer = Buffer.alloc(toRead);
+      fs.read(this.context.fd, buffer, 0, toRead, this.pos, (err, bytesRead) => {
+        if (err) {
+          this.destroy(err);
+        } else if (bytesRead === 0) {
+          this.destroyed = true;
+          this.push(null);
+          this.context.unref();
+        } else {
+          this.pos += bytesRead;
+          this.push(buffer.slice(0, bytesRead));
+        }
+        cb();
+      });
+    });
   }
 
-  readStream.end();
-  readStream.destroy = function() {
-    readStream.destroyed = true;
-  };
-  return readStream;
-};
+  destroy(err) {
+    if (this.destroyed) return;
+    err = err || new Error("stream destroyed");
+    this.destroyed = true;
+    this.emit('error', err);
+    this.context.unref();
+  }
+}
 
-BufferSlicer.prototype.createWriteStream = function(options) {
-  var bufferSlicer = this;
-  options = options || {};
-  var writeStream = new Writable(options);
-  writeStream.start = options.start || 0;
-  writeStream.endOffset = (options.end == null) ? this.buffer.length : +options.end;
-  writeStream.bytesWritten = 0;
-  writeStream.pos = writeStream.start;
-  writeStream.destroyed = false;
-  writeStream._write = function(buffer, encoding, callback) {
-    if (writeStream.destroyed) return;
+class WriteStream extends Writable {
+  constructor(context, options = {}) {
+    super(options);
 
-    var end = writeStream.pos + buffer.length;
-    if (end > writeStream.endOffset) {
-      var err = new Error("maximum file length exceeded");
+    this.context = context;
+    this.context.ref();
+
+    this.start = options.start || 0;
+    this.endOffset = (options.end == null) ? Infinity : +options.end;
+    this.bytesWritten = 0;
+    this.pos = this.start;
+    this.destroyed = false;
+
+    this.on('finish', this.destroy.bind(this));
+  }
+
+  _write(buffer, _encoding, callback) {
+    if (this.destroyed) return;
+
+    if (this.pos + buffer.length > this.endOffset) {
+      const err = new Error("maximum file length exceeded");
       err.code = 'ETOOBIG';
-      writeStream.destroyed = true;
+      this.destroy();
       callback(err);
       return;
     }
-    buffer.copy(bufferSlicer.buffer, writeStream.pos, 0, buffer.length);
-
-    writeStream.bytesWritten += buffer.length;
-    writeStream.pos = end;
-    writeStream.emit('progress');
-    callback();
-  };
-  writeStream.destroy = function() {
-    writeStream.destroyed = true;
-  };
-  return writeStream;
-};
-
-BufferSlicer.prototype.ref = function() {
-  this.refCount += 1;
-};
-
-BufferSlicer.prototype.unref = function() {
-  this.refCount -= 1;
-
-  if (this.refCount < 0) {
-    throw new Error("invalid unref");
+    this.context.pend.go(cb => {
+      if (this.destroyed) return cb();
+      fs.write(this.context.fd, buffer, 0, buffer.length, this.pos, (err, bytes) => {
+        if (err) {
+          this.destroy();
+          cb();
+          callback(err);
+        } else {
+          this.bytesWritten += bytes;
+          this.pos += bytes;
+          this.emit('progress');
+          cb();
+          callback();
+        }
+      });
+    });
   }
-};
+
+  destroy() {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    this.context.unref();
+  }
+}
+
+const { MAX_SAFE_INTEGER } = Number;
+
+class BufferSlicer extends EventEmitter {
+  constructor(buffer, options) {
+    super();
+
+    options = options || {};
+    this.refCount = 0;
+    this.buffer = buffer;
+    this.maxChunkSize = options.maxChunkSize || MAX_SAFE_INTEGER;
+  }
+
+  read(buffer, offset, length, position, callback) {
+    const end = position + length;
+    const delta = end - this.buffer.length;
+    const written = (delta > 0) ? delta : length;
+    this.buffer.copy(buffer, offset, position, end);
+    setImmediate(() => {
+      callback(null, written);
+    });
+  }
+
+  write(buffer, offset, length, position, callback) {
+    buffer.copy(this.buffer, position, offset, offset + length);
+    setImmediate(() => {
+      callback(null, length, buffer);
+    });
+  }
+
+  createReadStream(options = {}) {
+    const readStream = new PassThrough(options);
+    readStream.destroyed = false;
+    readStream.start = options.start || 0;
+    readStream.endOffset = options.end;
+    // by the time this function returns, we'll be done.
+    readStream.pos = readStream.endOffset || this.buffer.length;
+
+    // respect the maxChunkSize option to slice up the chunk into smaller pieces.
+    const entireSlice = this.buffer.slice(readStream.start, readStream.pos);
+    let offset = 0;
+    while (true) {
+      const nextOffset = offset + this.maxChunkSize;
+      if (nextOffset >= entireSlice.length) {
+        // last chunk
+        if (offset < entireSlice.length) {
+          readStream.write(entireSlice.slice(offset, entireSlice.length));
+        }
+        break;
+      }
+      readStream.write(entireSlice.slice(offset, nextOffset));
+      offset = nextOffset;
+    }
+
+    readStream.end();
+    readStream.destroy = () => {
+      readStream.destroyed = true;
+    };
+    return readStream;
+  }
+
+  createWriteStream(options) {
+    const bufferSlicer = this;
+    options = options || {};
+    const writeStream = new Writable(options);
+    writeStream.start = options.start || 0;
+    writeStream.endOffset = (options.end == null) ? this.buffer.length : +options.end;
+    writeStream.bytesWritten = 0;
+    writeStream.pos = writeStream.start;
+    writeStream.destroyed = false;
+    writeStream._write = (buffer, encoding, callback) => {
+      if (writeStream.destroyed) return;
+
+      const end = writeStream.pos + buffer.length;
+      if (end > writeStream.endOffset) {
+        const err = new Error("maximum file length exceeded");
+        err.code = 'ETOOBIG';
+        writeStream.destroyed = true;
+        callback(err);
+        return;
+      }
+      buffer.copy(bufferSlicer.buffer, writeStream.pos, 0, buffer.length);
+
+      writeStream.bytesWritten += buffer.length;
+      writeStream.pos = end;
+      writeStream.emit('progress');
+      callback();
+    };
+    writeStream.destroy = () => {
+      writeStream.destroyed = true;
+    };
+    return writeStream;
+  }
+
+  ref() {
+    this.refCount += 1;
+  }
+
+  unref() {
+    this.refCount -= 1;
+
+    if (this.refCount < 0) {
+      throw new Error("invalid unref");
+    }
+  }
+}
 
 function createFromBuffer(buffer, options) {
   return new BufferSlicer(buffer, options);
@@ -299,3 +280,8 @@ function createFromBuffer(buffer, options) {
 function createFromFd(fd, options) {
   return new FdSlicer(fd, options);
 }
+
+exports.createFromBuffer = createFromBuffer;
+exports.createFromFd = createFromFd;
+exports.BufferSlicer = BufferSlicer;
+exports.FdSlicer = FdSlicer;

--- a/package.json
+++ b/package.json
@@ -4,24 +4,26 @@
   "description": "safely create multiple ReadStream or WriteStream objects from the same file descriptor",
   "main": "index.js",
   "scripts": {
-    "test": "mocha --reporter spec --check-leaks",
-    "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --reporter dot --check-leaks test/test.js",
-    "test-travis": "istanbul cover node_modules/mocha/bin/_mocha --report lcovonly -- --timeout 10000 --reporter spec --check-leaks test/test.js"
+    "test": "mocha --check-leaks",
+    "coverage": "nyc mocha -- --reporter dot --check-leaks test/test.js"
   },
   "author": "Andrew Kelley <superjoe30@gmail.com>",
   "license": "MIT",
   "devDependencies": {
-    "istanbul": "~0.3.3",
-    "mocha": "~2.0.1",
-    "stream-equal": "~0.1.5",
-    "streamsink": "~1.2.0"
+    "mocha": "^7.0.1",
+    "nyc": "^15.0.0",
+    "stream-equal": "^1.1.1",
+    "streamsink": "^1.2.0"
   },
   "dependencies": {
-    "pend": "~1.2.0"
+    "pend": "^1.2.0"
   },
   "directories": {
     "test": "test"
   },
+  "files": [
+    "index.js"
+  ],
   "repository": {
     "type": "git",
     "url": "git://github.com/andrewrk/node-fd-slicer.git"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "scripts": {
     "test": "mocha --check-leaks",
-    "coverage": "nyc mocha -- --reporter dot --check-leaks test/test.js"
+    "test:coverage": "nyc mocha -- --reporter dot --check-leaks test/test.js"
   },
   "author": "Andrew Kelley <superjoe30@gmail.com>",
   "license": "MIT",

--- a/test/test.js
+++ b/test/test.js
@@ -1,57 +1,51 @@
-var fdSlicer = require('../');
-var fs = require('fs');
-var crypto = require('crypto');
-var path = require('path');
-var streamEqual = require('stream-equal');
-var assert = require('assert');
-var Pend = require('pend');
-var StreamSink = require('streamsink');
+const fdSlicer = require('../');
+const fs = require('fs');
+const crypto = require('crypto');
+const path = require('path');
+const streamEqual = require('stream-equal');
+const assert = require('assert');
+const Pend = require('pend');
+const StreamSink = require('streamsink');
 
-var describe = global.describe;
-var it = global.it;
-var before = global.before;
-var beforeEach = global.beforeEach;
-var after = global.after;
+const testBlobFile = path.join(__dirname, "test-blob.bin");
+const testBlobFileSize = 20 * 1024 * 1024;
+const testOutBlobFile = path.join(__dirname, "test-blob-out.bin");
 
-var testBlobFile = path.join(__dirname, "test-blob.bin");
-var testBlobFileSize = 20 * 1024 * 1024;
-var testOutBlobFile = path.join(__dirname, "test-blob-out.bin");
-
-describe("FdSlicer", function() {
-  before(function(done) {
-    var out = fs.createWriteStream(testBlobFile);
-    for (var i = 0; i < testBlobFileSize / 1024; i += 1) {
+describe("FdSlicer", () => {
+  before(done => {
+    const out = fs.createWriteStream(testBlobFile);
+    for (let i = 0; i < testBlobFileSize / 1024; i += 1) {
       out.write(crypto.pseudoRandomBytes(1024));
     }
     out.end();
     out.on('close', done);
   });
-  beforeEach(function() {
+  beforeEach(() => {
     try {
       fs.unlinkSync(testOutBlobFile);
     } catch (err) {
     }
   });
-  after(function() {
+  after(() => {
     try {
       fs.unlinkSync(testBlobFile);
       fs.unlinkSync(testOutBlobFile);
     } catch (err) {
     }
   });
-  it("reads a 20MB file (autoClose on)", function(done) {
-    fs.open(testBlobFile, 'r', function(err, fd) {
+  it("reads a 20MB file (autoClose on)", done => {
+    fs.open(testBlobFile, 'r', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var actualStream = slicer.createReadStream();
-      var expectedStream = fs.createReadStream(testBlobFile);
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const actualStream = slicer.createReadStream();
+      const expectedStream = fs.createReadStream(testBlobFile);
 
-      var pend = new Pend();
-      pend.go(function(cb) {
+      const pend = new Pend();
+      pend.go(cb => {
         slicer.on('close', cb);
       });
-      pend.go(function(cb) {
-        streamEqual(expectedStream, actualStream, function(err, equal) {
+      pend.go(cb => {
+        streamEqual(expectedStream, actualStream, (err, equal) => {
           if (err) return done(err);
           assert.ok(equal);
           cb();
@@ -60,62 +54,62 @@ describe("FdSlicer", function() {
       pend.wait(done);
     });
   });
-  it("reads 4 chunks simultaneously", function(done) {
-    fs.open(testBlobFile, 'r', function(err, fd) {
+  it("reads 4 chunks simultaneously", done => {
+    fs.open(testBlobFile, 'r', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd);
-      var actualPart1 = slicer.createReadStream({start: testBlobFileSize * 0/4, end: testBlobFileSize * 1/4});
-      var actualPart2 = slicer.createReadStream({start: testBlobFileSize * 1/4, end: testBlobFileSize * 2/4});
-      var actualPart3 = slicer.createReadStream({start: testBlobFileSize * 2/4, end: testBlobFileSize * 3/4});
-      var actualPart4 = slicer.createReadStream({start: testBlobFileSize * 3/4, end: testBlobFileSize * 4/4});
-      var expectedPart1 = slicer.createReadStream({start: testBlobFileSize * 0/4, end: testBlobFileSize * 1/4});
-      var expectedPart2 = slicer.createReadStream({start: testBlobFileSize * 1/4, end: testBlobFileSize * 2/4});
-      var expectedPart3 = slicer.createReadStream({start: testBlobFileSize * 2/4, end: testBlobFileSize * 3/4});
-      var expectedPart4 = slicer.createReadStream({start: testBlobFileSize * 3/4, end: testBlobFileSize * 4/4});
-      var pend = new Pend();
-      pend.go(function(cb) {
-        streamEqual(expectedPart1, actualPart1, function(err, equal) {
+      const slicer = fdSlicer.createFromFd(fd);
+      const actualPart1 = slicer.createReadStream({start: testBlobFileSize * 0/4, end: testBlobFileSize * 1/4});
+      const actualPart2 = slicer.createReadStream({start: testBlobFileSize * 1/4, end: testBlobFileSize * 2/4});
+      const actualPart3 = slicer.createReadStream({start: testBlobFileSize * 2/4, end: testBlobFileSize * 3/4});
+      const actualPart4 = slicer.createReadStream({start: testBlobFileSize * 3/4, end: testBlobFileSize * 4/4});
+      const expectedPart1 = slicer.createReadStream({start: testBlobFileSize * 0/4, end: testBlobFileSize * 1/4});
+      const expectedPart2 = slicer.createReadStream({start: testBlobFileSize * 1/4, end: testBlobFileSize * 2/4});
+      const expectedPart3 = slicer.createReadStream({start: testBlobFileSize * 2/4, end: testBlobFileSize * 3/4});
+      const expectedPart4 = slicer.createReadStream({start: testBlobFileSize * 3/4, end: testBlobFileSize * 4/4});
+      const pend = new Pend();
+      pend.go(cb => {
+        streamEqual(expectedPart1, actualPart1, (err, equal) => {
           assert.ok(equal);
           cb(err);
         });
       });
-      pend.go(function(cb) {
-        streamEqual(expectedPart2, actualPart2, function(err, equal) {
+      pend.go(cb => {
+        streamEqual(expectedPart2, actualPart2, (err, equal) => {
           assert.ok(equal);
           cb(err);
         });
       });
-      pend.go(function(cb) {
-        streamEqual(expectedPart3, actualPart3, function(err, equal) {
+      pend.go(cb => {
+        streamEqual(expectedPart3, actualPart3, (err, equal) => {
           assert.ok(equal);
           cb(err);
         });
       });
-      pend.go(function(cb) {
-        streamEqual(expectedPart4, actualPart4, function(err, equal) {
+      pend.go(cb => {
+        streamEqual(expectedPart4, actualPart4, (err, equal) => {
           assert.ok(equal);
           cb(err);
         });
       });
-      pend.wait(function(err) {
+      pend.wait(err => {
         if (err) return done(err);
         fs.close(fd, done);
       });
     });
   });
 
-  it("writes a 20MB file (autoClose on)", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("writes a 20MB file (autoClose on)", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var actualStream = slicer.createWriteStream();
-      var inStream = fs.createReadStream(testBlobFile);
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const actualStream = slicer.createWriteStream();
+      const inStream = fs.createReadStream(testBlobFile);
 
-      slicer.on('close', function() {
-        var expected = fs.createReadStream(testBlobFile);
-        var actual = fs.createReadStream(testOutBlobFile);
+      slicer.on('close', () => {
+        const expected = fs.createReadStream(testBlobFile);
+        const actual = fs.createReadStream(testOutBlobFile);
 
-        streamEqual(expected, actual, function(err, equal) {
+        streamEqual(expected, actual, (err, equal) => {
           if (err) return done(err);
           assert.ok(equal);
           done();
@@ -125,41 +119,41 @@ describe("FdSlicer", function() {
     });
   });
 
-  it("writes 4 chunks simultaneously", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("writes 4 chunks simultaneously", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd);
-      var actualPart1 = slicer.createWriteStream({start: testBlobFileSize * 0/4});
-      var actualPart2 = slicer.createWriteStream({start: testBlobFileSize * 1/4});
-      var actualPart3 = slicer.createWriteStream({start: testBlobFileSize * 2/4});
-      var actualPart4 = slicer.createWriteStream({start: testBlobFileSize * 3/4});
-      var in1 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 0/4, end: testBlobFileSize * 1/4});
-      var in2 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 1/4, end: testBlobFileSize * 2/4});
-      var in3 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 2/4, end: testBlobFileSize * 3/4});
-      var in4 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 3/4, end: testBlobFileSize * 4/4});
-      var pend = new Pend();
-      pend.go(function(cb) {
+      const slicer = fdSlicer.createFromFd(fd);
+      const actualPart1 = slicer.createWriteStream({start: testBlobFileSize * 0/4});
+      const actualPart2 = slicer.createWriteStream({start: testBlobFileSize * 1/4});
+      const actualPart3 = slicer.createWriteStream({start: testBlobFileSize * 2/4});
+      const actualPart4 = slicer.createWriteStream({start: testBlobFileSize * 3/4});
+      const in1 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 0/4, end: testBlobFileSize * 1/4});
+      const in2 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 1/4, end: testBlobFileSize * 2/4});
+      const in3 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 2/4, end: testBlobFileSize * 3/4});
+      const in4 = fs.createReadStream(testBlobFile, {start: testBlobFileSize * 3/4, end: testBlobFileSize * 4/4});
+      const pend = new Pend();
+      pend.go(cb => {
         actualPart1.on('finish', cb);
       });
-      pend.go(function(cb) {
+      pend.go(cb => {
         actualPart2.on('finish', cb);
       });
-      pend.go(function(cb) {
+      pend.go(cb => {
         actualPart3.on('finish', cb);
       });
-      pend.go(function(cb) {
+      pend.go(cb => {
         actualPart4.on('finish', cb);
       });
       in1.pipe(actualPart1);
       in2.pipe(actualPart2);
       in3.pipe(actualPart3);
       in4.pipe(actualPart4);
-      pend.wait(function() {
-        fs.close(fd, function(err) {
+      pend.wait(() => {
+        fs.close(fd, err => {
           if (err) return done(err);
-          var expected = fs.createReadStream(testBlobFile);
-          var actual = fs.createReadStream(testOutBlobFile);
-          streamEqual(expected, actual, function(err, equal) {
+          const expected = fs.createReadStream(testBlobFile);
+          const actual = fs.createReadStream(testOutBlobFile);
+          streamEqual(expected, actual, (err, equal) => {
             if (err) return done(err);
             assert.ok(equal);
             done();
@@ -169,117 +163,117 @@ describe("FdSlicer", function() {
     });
   });
 
-  it("throws on invalid ref", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("throws on invalid ref", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      assert.throws(function() {
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      assert.throws(() => {
         slicer.unref();
       }, /invalid unref/);
       fs.close(fd, done);
     });
   });
 
-  it("write stream emits error when max size exceeded", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("write stream emits error when max size exceeded", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var ws = slicer.createWriteStream({start: 0, end: 1000});
-      ws.on('error', function(err) {
-        assert.strictEqual(err.code, 'ETOOBIG');
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const ws = slicer.createWriteStream({start: 0, end: 1000});
+      ws.on('error', ({code}) => {
+        assert.strictEqual(code, 'ETOOBIG');
         slicer.on('close', done);
       });
-      ws.end(new Buffer(1001));
+      ws.end(Buffer.alloc(1001));
     });
   });
 
-  it("write stream does not emit error when max size not exceeded", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("write stream does not emit error when max size not exceeded", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var ws = slicer.createWriteStream({end: 1000});
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const ws = slicer.createWriteStream({end: 1000});
       slicer.on('close', done);
-      ws.end(new Buffer(1000));
+      ws.end(Buffer.alloc(1000));
     });
   });
 
-  it("write stream start and end work together", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("write stream start and end work together", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var ws = slicer.createWriteStream({start: 1, end: 1000});
-      ws.on('error', function(err) {
-        assert.strictEqual(err.code, 'ETOOBIG');
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const ws = slicer.createWriteStream({start: 1, end: 1000});
+      ws.on('error', ({code}) => {
+        assert.strictEqual(code, 'ETOOBIG');
         slicer.on('close', done);
       });
-      ws.end(new Buffer(1000));
+      ws.end(Buffer.alloc(1000));
     });
   });
 
-  it("write stream emits progress events", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("write stream emits progress events", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var ws = slicer.createWriteStream();
-      var progressEventCount = 0;
-      var prevBytesWritten = 0;
-      ws.on('progress', function() {
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const ws = slicer.createWriteStream();
+      let progressEventCount = 0;
+      let prevBytesWritten = 0;
+      ws.on('progress', () => {
         progressEventCount += 1;
         assert.ok(ws.bytesWritten > prevBytesWritten);
         prevBytesWritten = ws.bytesWritten;
       });
-      slicer.on('close', function() {
+      slicer.on('close', () => {
         assert.ok(progressEventCount > 5);
         done();
       });
-      for (var i = 0; i < 10; i += 1) {
-        ws.write(new Buffer(16 * 1024 * 2));
+      for (let i = 0; i < 10; i += 1) {
+        ws.write(Buffer.alloc(16 * 1024 * 2));
       }
       ws.end();
     });
   });
 
-  it("write stream unrefs when destroyed", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("write stream unrefs when destroyed", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var ws = slicer.createWriteStream();
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const ws = slicer.createWriteStream();
       slicer.on('close', done);
-      ws.write(new Buffer(1000));
+      ws.write(Buffer.alloc(1000));
       ws.destroy();
     });
   });
 
-  it("read stream unrefs when destroyed", function(done) {
-    fs.open(testBlobFile, 'r', function(err, fd) {
+  it("read stream unrefs when destroyed", done => {
+    fs.open(testBlobFile, 'r', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd, {autoClose: true});
-      var rs = slicer.createReadStream();
-      rs.on('error', function(err) {
-        assert.strictEqual(err.message, "stream destroyed");
+      const slicer = fdSlicer.createFromFd(fd, {autoClose: true});
+      const rs = slicer.createReadStream();
+      rs.on('error', ({message}) => {
+        assert.strictEqual(message, "stream destroyed");
         slicer.on('close', done);
       });
       rs.destroy();
     });
   });
 
-  it("fdSlicer.read", function(done) {
-    fs.open(testBlobFile, 'r', function(err, fd) {
+  it("fdSlicer.read", done => {
+    fs.open(testBlobFile, 'r', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd);
-      var outBuf = new Buffer(1024);
-      slicer.read(outBuf, 0, 10, 0, function(err, bytesRead, buf) {
+      const slicer = fdSlicer.createFromFd(fd);
+      const outBuf = Buffer.alloc(1024);
+      slicer.read(outBuf, 0, 10, 0, (err, bytesRead, buf) => {
         assert.strictEqual(bytesRead, 10);
         fs.close(fd, done);
       });
     });
   });
 
-  it("fdSlicer.write", function(done) {
-    fs.open(testOutBlobFile, 'w', function(err, fd) {
+  it("fdSlicer.write", done => {
+    fs.open(testOutBlobFile, 'w', (err, fd) => {
       if (err) return done(err);
-      var slicer = fdSlicer.createFromFd(fd);
-      slicer.write(new Buffer("blah\n"), 0, 5, 0, function() {
+      const slicer = fdSlicer.createFromFd(fd);
+      slicer.write(Buffer.from("blah\n"), 0, 5, 0, () => {
         if (err) return done(err);
         fs.close(fd, done);
       });
@@ -287,58 +281,58 @@ describe("FdSlicer", function() {
   });
 });
 
-describe("BufferSlicer", function() {
-  it("invalid ref", function() {
-    var slicer = fdSlicer.createFromBuffer(new Buffer(16));
+describe("BufferSlicer", () => {
+  it("invalid ref", () => {
+    const slicer = fdSlicer.createFromBuffer(Buffer.alloc(16));
     slicer.ref();
     slicer.unref();
-    assert.throws(function() {
+    assert.throws(() => {
       slicer.unref();
     }, /invalid unref/);
   });
-  it("read and write", function(done) {
-    var buf = new Buffer("through the tangled thread the needle finds its way");
-    var slicer = fdSlicer.createFromBuffer(buf);
-    var outBuf = new Buffer(1024);
-    slicer.read(outBuf, 10, 11, 8, function(err) {
+  it("read and write", done => {
+    const buf = Buffer.from("through the tangled thread the needle finds its way");
+    const slicer = fdSlicer.createFromBuffer(buf);
+    const outBuf = Buffer.alloc(1024);
+    slicer.read(outBuf, 10, 11, 8, err => {
       if (err) return done(err);
       assert.strictEqual(outBuf.toString('utf8', 10, 21), "the tangled");
-      slicer.write(new Buffer("derp"), 0, 4, 7, function(err) {
+      slicer.write(Buffer.from("derp"), 0, 4, 7, err => {
         if (err) return done(err);
         assert.strictEqual(buf.toString('utf8', 7, 19), "derp tangled");
         done();
       });
     });
   });
-  it("createReadStream", function(done) {
-    var str = "I never conquered rarely came, 16 just held such better days";
-    var buf = new Buffer(str);
-    var slicer = fdSlicer.createFromBuffer(buf);
-    var inStream = slicer.createReadStream();
-    var sink = new StreamSink();
+  it("createReadStream", done => {
+    const str = "I never conquered rarely came, 16 just held such better days";
+    const buf = Buffer.from(str);
+    const slicer = fdSlicer.createFromBuffer(buf);
+    const inStream = slicer.createReadStream();
+    const sink = new StreamSink();
     inStream.pipe(sink);
-    sink.on('finish', function() {
+    sink.on('finish', () => {
       assert.strictEqual(sink.toString(), str);
       inStream.destroy();
       done();
     });
   });
-  it("createWriteStream exceed buffer size", function(done) {
-    var slicer = fdSlicer.createFromBuffer(new Buffer(4));
-    var outStream = slicer.createWriteStream();
-    outStream.on('error', function(err) {
-      assert.strictEqual(err.code, 'ETOOBIG');
+  it("createWriteStream exceed buffer size", done => {
+    const slicer = fdSlicer.createFromBuffer(Buffer.alloc(4));
+    const outStream = slicer.createWriteStream();
+    outStream.on('error', ({code}) => {
+      assert.strictEqual(code, 'ETOOBIG');
       done();
     });
     outStream.write("hi!\n");
     outStream.write("it warked\n");
     outStream.end();
   });
-  it("createWriteStream ok", function(done) {
-    var buf = new Buffer(1024);
-    var slicer = fdSlicer.createFromBuffer(buf);
-    var outStream = slicer.createWriteStream();
-    outStream.on('finish', function() {
+  it("createWriteStream ok", done => {
+    const buf = Buffer.alloc(1024);
+    const slicer = fdSlicer.createFromBuffer(buf);
+    const outStream = slicer.createWriteStream();
+    outStream.on('finish', () => {
       assert.strictEqual(buf.toString('utf8', 0, "hi!\nit warked\n".length), "hi!\nit warked\n");
       outStream.destroy();
       done();


### PR DESCRIPTION
Upgrading fd-slicer package for more modern node version with improvements
```
ERROR  [DEP0005] DeprecationWarning: Buffer() is deprecated due to security and usability issues. Please use the Buffer.alloc(), Buffer.allocUnsafe(), or Buffer.from() methods instead.
```
